### PR TITLE
Better documentation for AddFunction

### DIFF
--- a/management_api.go
+++ b/management_api.go
@@ -320,6 +320,7 @@ func (e *Enforcer) RemoveFilteredNamedGroupingPolicy(ptype string, fieldIndex in
 }
 
 // AddFunction adds a customized function.
+// The added function may only return a float64, string, bool, or an array of these three types.
 func (e *Enforcer) AddFunction(name string, function govaluate.ExpressionFunction) {
 	e.fm.AddFunction(name, function)
 }


### PR DESCRIPTION
It isn't clear to someone adding a function that the underlying libraries used here impose some restrictions for this, requiring that one return a float64, string, or bool (or arrays of these).